### PR TITLE
Fix nil dereference when one or more nodes are offline

### DIFF
--- a/pkg/linstorcontrol/linstorcontrol.go
+++ b/pkg/linstorcontrol/linstorcontrol.go
@@ -48,7 +48,7 @@ func StatusFromResources(serviceCfgPath string, definition *client.ResourceDefin
 	for _, nodeRsc := range resources {
 		nodes = append(nodes, nodeRsc.NodeName)
 
-		if nodeRsc.State.InUse != nil && *nodeRsc.State.InUse {
+		if nodeRsc.State != nil && nodeRsc.State.InUse != nil && *nodeRsc.State.InUse {
 			primary = nodeRsc.NodeName
 		}
 


### PR DESCRIPTION
We ran into a panic while trying to run `linstor-gateway iscsi list` on our cluster while a node was offline. This is because when a node is offline, `nodeRsc.State` is going to be `nil`. This PR fixes that issue.